### PR TITLE
Fix broken case class contract for TaxIds

### DIFF
--- a/src/test/scala/uk/gov/hmrc/domain/TaxIdsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/TaxIdsSpec.scala
@@ -33,7 +33,7 @@ class TaxIdsSpec extends WordSpec with Matchers with LoneElement {
     }
 
     "fail to create a TaxIds object with no tax identifiers" in {
-      val ex = the[IllegalArgumentException] thrownBy new TaxIds()
+      val ex = the[IllegalArgumentException] thrownBy TaxIds()
       ex should have('message("requirement failed: TaxIds must have at least one TaxIdentifier"))
     }
   }


### PR DESCRIPTION
The old case class had a private constructor parameter, this was breaking the contract for case classes and had several disadvantages:
- It's a non-standard use case for a case class, potentially confusing users who are fairly new to Scala
- The private constructor param (the List) is still getting used for structural equality, leading to unexpected behaviour, as the public Set property is not used for equality. We had tests in other projects failing as a consequence of this odd behaviour.

There is a new apply method in the companion object now instead, so that new instances can still be created in the same way. The change is backwards compatible.

The as method has been simplified in addition.
