### PR TITLE
Change nino regex to have suffix of A-D

### DIFF
--- a/src/main/scala/uk/gov/hmrc/domain/Nino.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Nino.scala
@@ -33,7 +33,7 @@ object Nino {
   implicit val ninoWrite: Writes[Nino] = new SimpleObjectWrites[Nino](_.value)
   implicit val ninoRead: Reads[Nino] = new SimpleObjectReads[Nino]("nino", Nino.apply)
 
-  private val validNinoFormat = "[[A-Z]&&[^DFIQUV]][[A-Z]&&[^DFIQUVO]] ?\\d{2} ?\\d{2} ?\\d{2} ?[A-Z]{1}"
+  private val validNinoFormat = "[[A-Z]&&[^DFIQUV]][[A-Z]&&[^DFIQUVO]] ?\\d{2} ?\\d{2} ?\\d{2} ?[A-D]{1}"
   private val invalidPrefixes = List("BG", "GB", "NK", "KN", "TN", "NT", "ZZ")
 
   private def hasValidPrefix(nino: String) = invalidPrefixes.find(nino.startsWith).isEmpty

--- a/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
@@ -58,6 +58,10 @@ class NinoSpec extends WordSpec with Matchers {
     "fail if the second letter O" in {
       validateNino("AO123456C") should equal (false)
     }
+
+    "fail if the suffix is E" in {
+      validateNino("AB123456E") should equal (false)
+    }
   }
 
   "Creating a Nino" should {


### PR DESCRIPTION
The suffix of NINOs is supposed to be a character A-D.

http://www.hmrc.gov.uk/manuals/nimmanual/nim39110.htm
