### PR TITLE
add function definition type to companion objects

### DIFF
--- a/src/main/scala/uk/gov/hmrc/domain/AgentBusinessUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AgentBusinessUtr.scala
@@ -25,7 +25,7 @@ case class AgentBusinessUtr(utr: String) extends TaxIdentifier with SimpleName {
   def value = utr
 }
 
-object AgentBusinessUtr extends CheckCharacter {
+object AgentBusinessUtr extends CheckCharacter with (String => AgentBusinessUtr) {
   implicit val agentBusinessUtrWrite: Writes[AgentBusinessUtr] = new SimpleObjectWrites[AgentBusinessUtr](_.value)
   implicit val agentBusinessUtrRead: Reads[AgentBusinessUtr] = new SimpleObjectReads[AgentBusinessUtr]("utr", AgentBusinessUtr.apply)
 

--- a/src/main/scala/uk/gov/hmrc/domain/AgentCode.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AgentCode.scala
@@ -22,7 +22,7 @@ case class AgentCode(value: String) extends TaxIdentifier {
   override def toString = value
 }
 
-object AgentCode {
+object AgentCode extends (String => AgentCode) {
   implicit val agentCodeWrite: Writes[AgentCode] = new SimpleObjectWrites[AgentCode](_.value)
   implicit val agentCodeRead: Reads[AgentCode] = new SimpleObjectReads[AgentCode]("agentCode", AgentCode.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/AgentUserId.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AgentUserId.scala
@@ -22,7 +22,7 @@ case class AgentUserId(value: String) extends TaxIdentifier {
   override def toString = value
 }
 
-object AgentUserId {
+object AgentUserId extends (String => AgentUserId) {
   implicit val agentUserIdWrite: Writes[AgentUserId] = new SimpleObjectWrites[AgentUserId](_.value)
   implicit val agentUserIdRead: Reads[AgentUserId] = new SimpleObjectReads[AgentUserId]("agentUserId", AgentUserId.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/AtedUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AtedUtr.scala
@@ -25,7 +25,7 @@ case class AtedUtr(utr: String) extends TaxIdentifier with SimpleName {
   def value = utr
 }
 
-object AtedUtr extends CheckCharacter {
+object AtedUtr extends CheckCharacter with (String => AtedUtr) {
   implicit val atedUtrWrite: Writes[AtedUtr] = new SimpleObjectWrites[AtedUtr](_.value)
   implicit val atedUtrRead: Reads[AtedUtr] = new SimpleObjectReads[AtedUtr]("utr", AtedUtr.apply)
 

--- a/src/main/scala/uk/gov/hmrc/domain/AwrsUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AwrsUtr.scala
@@ -24,7 +24,7 @@ case class AwrsUtr(utr: String) extends TaxIdentifier with SimpleName {
   def value = utr
 }
 
-object AwrsUtr {
+object AwrsUtr extends (String => AwrsUtr) {
   implicit val awrsUtrWrite: Writes[AwrsUtr] = new SimpleObjectWrites[AwrsUtr](_.value)
   implicit val awrsUtrRead: Reads[AwrsUtr] = new SimpleObjectReads[AwrsUtr]("utr", AwrsUtr.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/CtUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/CtUtr.scala
@@ -25,7 +25,7 @@ case class CtUtr(utr: String) extends TaxIdentifier with SimpleName {
   def value = utr
 }
 
-object CtUtr {
+object CtUtr extends (String => CtUtr) {
   implicit val ctUtrWrite: Writes[CtUtr] = new SimpleObjectWrites[CtUtr](_.value)
   implicit val ctUtrRead: Reads[CtUtr] = new SimpleObjectReads[CtUtr]("utr", CtUtr.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
@@ -28,7 +28,7 @@ case class EmpRef(taxOfficeNumber: String, taxOfficeReference: String) extends T
   def encodedValue = URLEncoder.encode(value, "UTF-8")
 }
 
-object EmpRef {
+object EmpRef extends ((String, String) => EmpRef){
 
   implicit val empRefWrite: Writes[EmpRef] = new SimpleObjectWrites[EmpRef](_.value)
   implicit val empRefRead: Reads[EmpRef] = new Reads[EmpRef] {

--- a/src/main/scala/uk/gov/hmrc/domain/Nino.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Nino.scala
@@ -29,7 +29,7 @@ case class Nino(nino: String) extends TaxIdentifier with SimpleName {
   def formatted = value.grouped(2).mkString(" ")
 }
 
-object Nino {
+object Nino extends (String => Nino) {
   implicit val ninoWrite: Writes[Nino] = new SimpleObjectWrites[Nino](_.value)
   implicit val ninoRead: Reads[Nino] = new SimpleObjectReads[Nino]("nino", Nino.apply)
 

--- a/src/main/scala/uk/gov/hmrc/domain/Org.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Org.scala
@@ -24,7 +24,7 @@ case class Org(org: String) extends TaxIdentifier with SimpleName {
   def value = org
 }
 
-object Org {
+object Org  extends (String => Org) {
   implicit val orgWrite: Writes[Org] = new SimpleObjectWrites[Org](_.value)
   implicit val orgRead: Reads[Org] = new SimpleObjectReads[Org]("org", Org.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/PayeAgentReference.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/PayeAgentReference.scala
@@ -22,7 +22,7 @@ case class PayeAgentReference(value: String) extends TaxIdentifier {
   override def toString = value
 }
 
-object PayeAgentReference {
+object PayeAgentReference extends (String => PayeAgentReference) {
   implicit val agencyPayeReferenceWrite: Writes[PayeAgentReference] = new SimpleObjectWrites[PayeAgentReference](_.value)
   implicit val agencyPayeReferenceRead: Reads[PayeAgentReference] = new SimpleObjectReads[PayeAgentReference]("payeAgentReference", PayeAgentReference.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/PsaId.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/PsaId.scala
@@ -25,7 +25,7 @@ case class PsaId(id: String) extends TaxIdentifier with SimpleName {
   def value = id
 }
 
-object PsaId {
+object PsaId  extends (String => PsaId) {
   implicit val psaIdWrite: Writes[PsaId] = new SimpleObjectWrites[PsaId](_.value)
   implicit val psaIdRead: Reads[PsaId] = new SimpleObjectReads[PsaId]("id", PsaId.apply)
 

--- a/src/main/scala/uk/gov/hmrc/domain/SaUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/SaUtr.scala
@@ -25,7 +25,7 @@ case class SaUtr(utr: String) extends TaxIdentifier with SimpleName {
   val name = "sautr"
 }
 
-object SaUtr {
+object SaUtr extends (String => SaUtr) {
   implicit val saUtrWrite: Writes[SaUtr] = new SimpleObjectWrites[SaUtr](_.value)
   implicit val saUtrRead: Reads[SaUtr] = new SimpleObjectReads[SaUtr]("utr", SaUtr.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/Uar.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Uar.scala
@@ -24,7 +24,7 @@ case class Uar(uar: String) extends TaxIdentifier with SimpleName {
   def value = uar
 }
 
-object Uar {
+object Uar extends (String => Uar) {
   implicit val uarWrite: Writes[Uar] = new SimpleObjectWrites[Uar](_.value)
   implicit val uarRead: Reads[Uar] = new SimpleObjectReads[Uar]("uar", Uar.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/Vrn.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Vrn.scala
@@ -24,7 +24,7 @@ case class Vrn(vrn: String) extends TaxIdentifier with SimpleName {
   def value = vrn
 }
 
-object Vrn {
+object Vrn extends (String => Vrn) {
   implicit val vrnWrite: Writes[Vrn] = new SimpleObjectWrites[Vrn](_.value)
   implicit val vrnRead: Reads[Vrn] = new SimpleObjectReads[Vrn]("vrn", Vrn.apply)
 }


### PR DESCRIPTION
Adding the constructor signature to the companion object of a case class allows the object to be used as a constructor function without method names and underscores
e.g.
var maybeNinoStr: Option[String] = Some("<redacted>")
var maybeNino = maybeNinoStr.map(Nino.apply(_))

.. should be ..
var maybeNino = maybeNinoStr.map(Nino)
