### PR TITLE
Add generator for SA UTRs

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -26,7 +26,8 @@ object HmrcBuild extends Build {
     Dependencies.Compile.playJson,
     Dependencies.Test.scalaTest,
     Dependencies.Test.pegdown,
-    Dependencies.Test.scalaCheck
+    Dependencies.Test.scalaCheck,
+    Dependencies.Test.referenceCheck
   )
 
   lazy val domain = (project in file("."))
@@ -52,6 +53,7 @@ object Dependencies {
     val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % scope
     val pegdown = "org.pegdown" % "pegdown" % "1.5.0" % scope
     val scalaCheck = "org.scalacheck" %% "scalacheck" % "1.12.5" % scope
+    val referenceCheck = "uk.gov.hmrc" %% "reference-checker" % "2.0.0" % scope
   }
 
   object Test extends Test("test")

--- a/src/main/scala/uk/gov/hmrc/domain/AgentCode.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AgentCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/AgentUserId.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/AgentUserId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/CtUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/CtUtr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/Modulus11Check.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Modulus11Check.scala
@@ -16,15 +16,10 @@
 
 package uk.gov.hmrc.domain
 
-import play.api.libs.json.{Reads, Writes}
+trait Modulus11Check extends ModulusCheck {
 
-case class AwrsUtr(utr: String) extends TaxIdentifier with SimpleName {
-  override def toString = utr
-  val name = "awrsutr"
-  def value = utr
-}
+  override protected val checkString = "21987654321"
+  override protected val mod = 11
+  override protected val weights = List(6, 7, 8, 9, 10, 5, 4, 3, 2)
 
-object AwrsUtr extends (String => AwrsUtr) {
-  implicit val awrsUtrWrite: Writes[AwrsUtr] = new SimpleObjectWrites[AwrsUtr](_.value)
-  implicit val awrsUtrRead: Reads[AwrsUtr] = new SimpleObjectReads[AwrsUtr]("utr", AwrsUtr.apply)
 }

--- a/src/main/scala/uk/gov/hmrc/domain/Modulus23Check.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Modulus23Check.scala
@@ -16,28 +16,10 @@
 
 package uk.gov.hmrc.domain
 
-trait Modulus23Check {
+trait Modulus23Check extends ModulusCheck {
 
-  protected val checkString = "ABCDEFGHXJKLMNYPQRSTZVW"
-  protected val mod = 23
-  protected val weights = List(9, 10, 11, 12, 13, 8, 7, 6, 5, 4, 3, 2, 1)
-
-  protected def isCheckCorrect(utr: String, checkPosition: Int, offset: Int): Boolean = utr.charAt(checkPosition) == getCheckCharacter(utr, offset)
-
-  protected def calculateCheckCharacter(utr: String) = getCheckCharacter(utr, 0)
-
-  private def getCheckCharacter(utr: String, offset: Int): Char = {
-    val sum = weights.zipWithIndex.collect {
-      case (weight, index) if index + offset < utr.length =>
-        val char = utr.charAt(index + offset)
-        if (char.isLetter) {
-          weight * (char.asDigit + mod)
-        } else {
-          weight * char.asDigit
-        }
-    }.sum
-
-    checkString.charAt(sum % mod)
-  }
+  override protected val checkString = "ABCDEFGHXJKLMNYPQRSTZVW"
+  override protected val mod = 23
+  override protected val weights = List(9, 10, 11, 12, 13, 8, 7, 6, 5, 4, 3, 2, 1)
 
 }

--- a/src/main/scala/uk/gov/hmrc/domain/ModulusCheck.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/ModulusCheck.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.domain
+
+trait ModulusCheck {
+
+  protected val checkString: String
+  protected val mod: Int
+  protected val weights: List[Int]
+
+  protected def isCheckCorrect(utr: String, checkPosition: Int, offset: Int): Boolean = utr.charAt(checkPosition) == getCheckCharacter(utr, offset)
+
+  protected def calculateCheckCharacter(utr: String) = getCheckCharacter(utr, 0)
+
+  private def getCheckCharacter(utr: String, offset: Int): Char = {
+    val sum = weights.zipWithIndex.collect {
+      case (weight, index) if index + offset < utr.length =>
+        val char = utr.charAt(index + offset)
+        if (char.isLetter) {
+          weight * (char.asDigit + mod)
+        } else {
+          weight * char.asDigit
+        }
+    }.sum
+
+    checkString.charAt(sum % mod)
+  }
+
+}

--- a/src/main/scala/uk/gov/hmrc/domain/Nino.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Nino.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/Org.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Org.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/PayeAgentReference.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/PayeAgentReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/PsaId.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/PsaId.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/SaAgentReference.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/SaAgentReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/SaUtr.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/SaUtr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/SaUtrGenerator.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/SaUtrGenerator.scala
@@ -16,15 +16,14 @@
 
 package uk.gov.hmrc.domain
 
-import play.api.libs.json.{Reads, Writes}
+import scala.util.Random
 
-case class AwrsUtr(utr: String) extends TaxIdentifier with SimpleName {
-  override def toString = utr
-  val name = "awrsutr"
-  def value = utr
-}
+class SaUtrGenerator(random: Random = new Random) extends Modulus11Check {
+  def this(seed: Int) = this(new scala.util.Random(seed))
 
-object AwrsUtr extends (String => AwrsUtr) {
-  implicit val awrsUtrWrite: Writes[AwrsUtr] = new SimpleObjectWrites[AwrsUtr](_.value)
-  implicit val awrsUtrRead: Reads[AwrsUtr] = new SimpleObjectReads[AwrsUtr]("utr", AwrsUtr.apply)
+  def nextSaUtr: SaUtr = {
+    val suffix = f"${random.nextInt(100000)}%09d"
+    val checkCharacter  = calculateCheckCharacter(suffix)
+    SaUtr(s"$checkCharacter$suffix")
+  }
 }

--- a/src/main/scala/uk/gov/hmrc/domain/SimpleObjectFormats.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/SimpleObjectFormats.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/TaxCode.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/TaxCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/Uar.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Uar.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/Vrn.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Vrn.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/taxIdentifiers.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/taxIdentifiers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/uk/gov/hmrc/domain/taxIds.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/taxIds.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/AgentBusinessUtrSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/AgentBusinessUtrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/EmpRefTest.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/EmpRefTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/GeneratorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/GeneratorSpec.scala
@@ -40,5 +40,4 @@ class GeneratorSpec extends WordSpec with Checkers {
     }
 
   }
-
 }

--- a/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/PsaIdSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/PsaIdSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/SaUtrGeneratorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/SaUtrGeneratorSpec.scala
@@ -16,15 +16,16 @@
 
 package uk.gov.hmrc.domain
 
-import play.api.libs.json.{Reads, Writes}
+import org.scalacheck.Prop
+import org.scalatest.WordSpec
+import org.scalatest.prop.Checkers
+import uk.gov.hmrc.referencechecker.SelfAssessmentReferenceChecker
 
-case class AwrsUtr(utr: String) extends TaxIdentifier with SimpleName {
-  override def toString = utr
-  val name = "awrsutr"
-  def value = utr
-}
+class SaUtrGeneratorSpec extends WordSpec with Checkers {
 
-object AwrsUtr extends (String => AwrsUtr) {
-  implicit val awrsUtrWrite: Writes[AwrsUtr] = new SimpleObjectWrites[AwrsUtr](_.value)
-  implicit val awrsUtrRead: Reads[AwrsUtr] = new SimpleObjectReads[AwrsUtr]("utr", AwrsUtr.apply)
+  "SaUtr Generation" should {
+    "generate valid SaUtrs for all random seeds" in {
+      check(Prop.forAll { (seed: Int) => SelfAssessmentReferenceChecker.isValid(new SaUtrGenerator(seed).nextSaUtr.utr)})
+    }
+  }
 }

--- a/src/test/scala/uk/gov/hmrc/domain/TaxCodeFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/TaxCodeFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/TaxCodeSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/TaxCodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/uk/gov/hmrc/domain/TaxIdsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/TaxIdsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 HM Revenue & Customs
+ * Copyright 2016 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
All identifiers used in the open are to be generated. This PR adds support for generating SA UTRs that will be validated by the SA reference-checker.
