### PR TITLE
[OPS-424] Added checker to validate P800 reference strings.

### DIFF
--- a/src/main/scala/uk/gov/hmrc/referencechecker/P800ReferenceChecker.scala
+++ b/src/main/scala/uk/gov/hmrc/referencechecker/P800ReferenceChecker.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.referencechecker
+
+object P800ReferenceChecker {
+
+  private val regex = "^(AA|AB|AE|AH|AK|AL|AM|AP|AR|AS|AT|AW|AX|AY|AZ|BA|BB|BE|BH|BK|BL|BM|BT|CA|CB|CE|CH|CK|CL|CR|EA|EB|EE|EH|EK|EL|EM|EP|ER|ES|ET|EW|EX|EY|EZ|GY|HA|HB|HE|HH|HK|HL|HM|HP|HR|HS|HT|HW|HX|HY|HZ|JA|JB|JC|JE|JG|JH|JJ|JK|JL|JM|JN|JP|JR|JS|JT|JW|JX|JY|JZ|KA|KB|KC|KE|KH|KK|KL|KM|KP|KR|KS|KT|KW|KX|KY|KZ|LA|LB|LE|LH|LK|LL|LM|LP|LR|LS|LT|LW|LX|LY|LZ|MA|MW|MX|NA|NB|NE|NH|NL|NM|NP|NR|NS|NW|NX|NY|NZ|OA|OB|OE|OH|OK|OL|OM|OP|OR|OS|OX|PA|PB|PC|PE|PG|PH|PJ|PK|PL|PM|PN|PP|PR|PS|PT|PW|PX|PY|RA|RB|RE|RH|RK|RM|RP|RR|RS|RT|RW|RX|RY|RZ|SA|SB|SC|SE|SG|SH|SJ|SK|SL|SM|SN|SP|SR|SS|ST|SW|SX|SY|SZ|TA|TB|TE|TH|TK|TL|TM|TP|TR|TS|TT|TW|TX|TY|TZ|WA|WB|WE|WK|WL|WM|WP|YA|YB|YE|YH|YK|YL|YM|YP|YR|YS|YT|YW|YX|YY|YZ|ZA|ZB|ZE|ZH|ZK|ZL|ZM|ZP|ZR|ZS|ZT|ZW|ZX|ZY)[0-9]{6}[A-D]P800\\d{4}$"
+
+  def isValid(s: String): Boolean = s.matches(regex)
+}

--- a/src/test/scala/uk/gov/hmrc/referencechecker/P800ReferenceCheckerSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/referencechecker/P800ReferenceCheckerSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.referencechecker
+
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{Matchers, WordSpec}
+
+
+class P800ReferenceCheckerSpec extends WordSpec with TableDrivenPropertyChecks with Matchers {
+
+  val invalidReferences = Table(
+    ("Reference", "Problem"),
+    ("", "is empty"),
+    ("SJ12312DP8002016", "has NINO with 5 digits"),
+    ("SJ123123P8002016", "has NINO without last letter"),
+    ("AC123123DP8002016", "has NINO with invalid first letters"),
+    ("SJ123123D2016", "doesn't have P800"),
+    ("SJ123123DP800", "doesn't have a year"),
+    ("SJ123123DP800201g", "has invalid year")
+  )
+
+  "P800 checker" should {
+    "return true for valid P800 reference string" in {
+      P800ReferenceChecker.isValid("SJ123123DP8002016") shouldEqual true
+    }
+
+
+    forAll(invalidReferences) { (reference, problem) =>
+      s"return false for string '$reference' that $problem" in {
+        P800ReferenceChecker.isValid(reference) shouldEqual false
+      }
+    }
+  }
+}


### PR DESCRIPTION
We need to perform additional checks to handle P800 payments. This pull request is about adding a checker that validates P800 reference sent from underlying microservices.