### PR TITLE
Adding function to return the nino without the suffix

### DIFF
--- a/src/main/scala/uk/gov/hmrc/domain/Nino.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/Nino.scala
@@ -22,11 +22,15 @@ case class Nino(nino: String) extends TaxIdentifier with SimpleName {
   require(Nino.isValid(nino), s"$nino is not a valid nino.")
   override def toString = nino
 
+  private val LengthWithoutSuffix: Int = 8
+
   def value = nino
 
   val name = "nino"
 
   def formatted = value.grouped(2).mkString(" ")
+
+  def withoutSuffix = value.take(LengthWithoutSuffix)
 }
 
 object Nino extends (String => Nino) {

--- a/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/NinoSpec.scala
@@ -76,5 +76,11 @@ class NinoSpec extends WordSpec with Matchers {
     }
   }
 
+  "Removing a suffix" should {
+    "produce a nino without a suffix" in {
+      Nino("AA111111A").withoutSuffix shouldBe "AA111111"
+    }
+  }
+
   def validateNino(nino: String) = Nino.isValid(nino)
 }


### PR DESCRIPTION
There are several areas of the MDTP where a target function requires as one of its arguments a nino with its suffix removed.
The strip suffix functionality is duplicated in may areas of the code base