### PR TITLE
EmpRef regex was too loose

### DIFF
--- a/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,10 +43,10 @@ object EmpRef extends ((String, String) => EmpRef){
   }
 
   def fromIdentifiers(slashSeparatedIdentifiers: String): EmpRef = {
-    val empRefPattern = """([^/]*)/([^/]*)""".r
+    val empRefPattern = """(\d{3})/([a-zA-Z0-9]+)""".r
     URLDecoder.decode(slashSeparatedIdentifiers, "UTF-8") match {
       case empRefPattern(first, second) => EmpRef(first, second)
-      case _ => throw new IllegalArgumentException("EmpRef requires two identifiers separated by a slash")
+      case _ => throw new IllegalArgumentException("EmpRef is three numbers, a slash, and then numbers and letters")
     }
   }
 

--- a/src/test/scala/uk/gov/hmrc/domain/DomainTypeFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/DomainTypeFormatsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 HM Revenue & Customs
+ * Copyright 2018 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -164,15 +164,15 @@ class DomainTypeFormatsSpec extends WordSpec with Matchers {
   "EmpRef reader" should {
 
     "be able to read obsolete EmpRef structure from Mongo" in {
-      val dbStructure = JsObject(Seq("taxOfficeNumber" -> JsString("12345"), "taxOfficeReference" -> JsString("ref")))
+      val dbStructure = JsObject(Seq("taxOfficeNumber" -> JsString("123"), "taxOfficeReference" -> JsString("ref")))
       val result = EmpRef.empRefRead.reads(dbStructure)
-      result.get shouldBe EmpRef("12345", "ref")
+      result.get shouldBe EmpRef("123", "ref")
     }
 
     "be able to read string representation of EmpRef" in {
-      val restStructure = JsString("12345/ref")
+      val restStructure = JsString("123/ref")
       val result = EmpRef.empRefRead.reads(restStructure)
-      result.get shouldBe EmpRef("12345", "ref")
+      result.get shouldBe EmpRef("123", "ref")
     }
 
   }


### PR DESCRIPTION
Per https://www.gov.uk/hmrc-internal-manuals/paye-manual/paye055#employer-reference an employers reference is three digits, a slash, and then numbers and letters. The previous regex was 'not a slash', 'slash', 'not a slash'.
I've also tweaked the test cases since the test data was also wrong (Tax Offices never had five digit references).
Strictly, the second half of the pattern could be '{1,7}' instead of '+'