### PR TITLE
Updated EmpRef reads 

### DIFF
--- a/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
+++ b/src/main/scala/uk/gov/hmrc/domain/EmpRef.scala
@@ -34,6 +34,8 @@ object EmpRef extends ((String, String) => EmpRef){
   implicit val empRefRead: Reads[EmpRef] = new Reads[EmpRef] {
     override def reads(js: JsValue): JsResult[EmpRef] = js match {
       case v: JsString => v.validate[String].map(EmpRef.fromIdentifiers)
+      case v: JsObject if v.keys.contains("empRef") =>
+        (v \ "empRef").validate[String].map(EmpRef.fromIdentifiers)
       case v: JsObject => for {
         ton <- (v \ "taxOfficeNumber").validate[String]
         tor <- (v \ "taxOfficeReference").validate[String]

--- a/src/test/scala/uk/gov/hmrc/domain/DomainTypeFormatsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/domain/DomainTypeFormatsSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.domain
 
 import org.scalatest.{Matchers, WordSpec}
-import play.api.libs.json.{JsError, JsObject, JsString}
+import play.api.libs.json._
 
 class DomainTypeFormatsSpec extends WordSpec with Matchers {
 
@@ -172,6 +172,12 @@ class DomainTypeFormatsSpec extends WordSpec with Matchers {
     "be able to read string representation of EmpRef" in {
       val restStructure = JsString("12345/ref")
       val result = EmpRef.empRefRead.reads(restStructure)
+      result.get shouldBe EmpRef("12345", "ref")
+    }
+
+    s"be able to read an employer reference from a play-authorised-frontend EpayeAccount case class"  in {
+      val epayeAccount = Json.obj("links" -> "/epaye/12345%2Fref", "empRef" -> "12345/ref")
+      val result = EmpRef.empRefRead.reads(epayeAccount)
       result.get shouldBe EmpRef("12345", "ref")
     }
 


### PR DESCRIPTION
Small change made to the reads on `EmpRef` so that it is able to extract the employers reference from an `EpayeAccount` case class from `play-authorised-frontend` 

https://github.com/hmrc/play-authorised-frontend/blob/70d19d13608ac7553046f9bf9394056fa504e3f9/src/main/scala/uk/gov/hmrc/play/frontend/auth/connectors/domain/Authority.scala#L262