### PR TITLE
Update LibDependencies.scala

### DIFF
--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -2,15 +2,15 @@ import sbt._
 
 object LibDependencies {
   val play28 = Seq(
-    "com.typesafe.play" %% "play" % "2.8.21"
+    "com.typesafe.play" %% "play-json" % "2.8.2"
   )
 
   val play29 = Seq(
-    "com.typesafe.play" %% s"play" % "2.9.0"
+    "com.typesafe.play" %% s"play-json" % "2.9.0"
   )
 
   val play30 = Seq(
-    "org.playframework" %% s"play" % "3.0.0"
+    "org.playframework" %% s"play-json" % "3.0.0"
   )
 
   val test = Seq(


### PR DESCRIPTION
Updated dependencies to only depend on play-json, because depending on play is pulling in some extra bits that are causing problems with performance test repos gatling version due to evictions

DISCLAIMER - I don't know all the contexts this library is used in to understand if those extra transitive dependencies are needed by dependent repositories

without this, performance test repos who want to use uk.gov.hmrc:domain-play-30 need to exclude slf4j, like this:

```
"uk.gov.hmrc"  %% "domain-play-30"  % "9.0.0"  % Test exclude("org.slf4j", "slf4j-api")
```